### PR TITLE
Add docstrings and type hints to utility modules

### DIFF
--- a/src/audit_lib/citations.py
+++ b/src/audit_lib/citations.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 
 PAREN_BLOCK_RE = re.compile(r"\(([^()]+)\)")
 PAIR_RE = re.compile(r"([A-Z][^,;()]+?)\s*,\s*(\d{4}[a-z]?)")
@@ -7,8 +7,27 @@ NARR_RE = re.compile(r"\b([A-Z][A-Za-z'’\-]+(?:\s+(?:&|and)\s+[A-Z][A-Za-z'’
 AS_CITED_IN_RE = re.compile(r"\bas cited in\s+([A-Z][^,;()]+?)\s*,\s*(\d{4}[a-z]?)", re.I)
 PAGE_RE = re.compile(r"\bpp?\.\s*(\d+(?:\s*[-–]\s*\d+)?)", re.I)
 
-def _extract_parenthetical_pairs(sentence: str):
-    out = []
+def _extract_parenthetical_pairs(sentence: str) -> List[Dict[str, Any]]:
+    """Extract parenthetical citation information from a sentence.
+
+    Parameters
+    ----------
+    sentence: str
+        Sentence potentially containing parenthetical citations.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        A list of dictionaries describing each citation found. The list is
+        empty when no citations are present.
+
+    Notes
+    -----
+    No exceptions are raised; invalid input types will result in a
+    ``TypeError`` from the underlying regex operations.
+    """
+
+    out: List[Dict[str, Any]] = []
     for m in PAREN_BLOCK_RE.finditer(sentence):
         block = m.group(1)
         span = (m.start(), m.end())
@@ -45,8 +64,27 @@ def _extract_parenthetical_pairs(sentence: str):
             })
     return out
 
-def _extract_narrative_pairs(sentence: str):
-    out = []
+def _extract_narrative_pairs(sentence: str) -> List[Dict[str, Any]]:
+    """Extract narrative citation information from a sentence.
+
+    Parameters
+    ----------
+    sentence: str
+        Sentence potentially containing narrative citations.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        A list of dictionaries describing each citation found. The list is
+        empty when no citations are present.
+
+    Notes
+    -----
+    No exceptions are raised; invalid input types will result in a
+    ``TypeError`` from the underlying regex operations.
+    """
+
+    out: List[Dict[str, Any]] = []
     for m in NARR_RE.finditer(sentence):
         a, y = m.groups()
         span = (m.start(), m.end())
@@ -83,11 +121,29 @@ def _extract_narrative_pairs(sentence: str):
             })
     return out
 
-def parse_citations(sentence: str) -> List[Dict[str,Any]]:
+def parse_citations(sentence: str) -> List[Dict[str, Any]]:
+    """Parse all citation forms within a sentence.
+
+    Parameters
+    ----------
+    sentence: str
+        Sentence containing potential parenthetical or narrative citations.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        A list of unique citation dictionaries extracted from the sentence.
+
+    Notes
+    -----
+    No exceptions are raised; invalid input types will result in a
+    ``TypeError`` from the underlying regex operations.
+    """
+
     parenth = _extract_parenthetical_pairs(sentence)
     narr = _extract_narrative_pairs(sentence)
     seen = set()
-    out = []
+    out: List[Dict[str, Any]] = []
     for item in parenth + narr:
         key = (item["author"], item["year"], item["citation_type"], item["span"])
         if key not in seen:

--- a/src/audit_lib/csv_utils.py
+++ b/src/audit_lib/csv_utils.py
@@ -1,13 +1,60 @@
 import csv
-from typing import List, Dict, Any
-def write_csv(path: str, rows: List[Dict[str,Any]], fieldnames: List[str]):
+from typing import Any, Dict, List
+
+
+def write_csv(path: str, rows: List[Dict[str, Any]], fieldnames: List[str]) -> None:
+    """Write rows to a CSV file, overwriting any existing content.
+
+    Parameters
+    ----------
+    path: str
+        Destination file path.
+    rows: List[Dict[str, Any]]
+        Rows to write, each mapping field names to values.
+    fieldnames: List[str]
+        Ordered list of column names.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    OSError
+        If the file cannot be written.
+    """
+
     with open(path, "w", newline="", encoding="utf-8") as f:
         w = csv.DictWriter(f, fieldnames=fieldnames)
         w.writeheader()
         for r in rows:
             w.writerow(r)
-def append_csv(path: str, rows: List[Dict[str,Any]], fieldnames: List[str]):
+
+
+def append_csv(path: str, rows: List[Dict[str, Any]], fieldnames: List[str]) -> None:
+    """Append rows to a CSV file, creating the file if needed.
+
+    Parameters
+    ----------
+    path: str
+        Destination file path.
+    rows: List[Dict[str, Any]]
+        Rows to append.
+    fieldnames: List[str]
+        Ordered list of column names.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    OSError
+        If the file cannot be written.
+    """
+
     import os
+
     exists = os.path.exists(path)
     with open(path, "a", newline="", encoding="utf-8") as f:
         w = csv.DictWriter(f, fieldnames=fieldnames)

--- a/src/audit_lib/pdf_utils.py
+++ b/src/audit_lib/pdf_utils.py
@@ -1,17 +1,60 @@
 from typing import Dict
 from pypdf import PdfReader
+
+
 def pdf_to_text_with_page_markers(pdf_path: str) -> str:
+    """Extract text from a PDF, inserting page markers.
+
+    Parameters
+    ----------
+    pdf_path: str
+        Path to the PDF file to read.
+
+    Returns
+    -------
+    str
+        Text of the PDF with markers of the form ``<<<PAGE=n>>>`` before each
+        page's content.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``pdf_path`` does not exist.
+    PdfReadError
+        Propagated from :class:`pypdf.PdfReader` when the file cannot be read.
+    """
+
     reader = PdfReader(pdf_path)
-    out_lines = []
+    out_lines: list[str] = []
     for i, page in enumerate(reader.pages, start=1):
         out_lines.append(f"<<<PAGE={i}>>>")
         text = page.extract_text() or ""
         out_lines.append(text.strip())
     return "\n".join(out_lines)
+
+
 def split_pages(text_with_markers: str) -> Dict[int, str]:
-    pages = {}
-    current_page = None
-    buf = []
+    """Split page-marked text back into individual pages.
+
+    Parameters
+    ----------
+    text_with_markers: str
+        Text produced by :func:`pdf_to_text_with_page_markers`.
+
+    Returns
+    -------
+    Dict[int, str]
+        Mapping of page numbers to their text content.
+
+    Notes
+    -----
+    Lines without page markers are associated with the current page. No
+    exceptions are raised unless the input format is malformed.
+    """
+
+    pages: Dict[int, str] = {}
+    current_page: int | None = None
+    buf: list[str] = []
     for line in text_with_markers.splitlines():
         if line.startswith("<<<PAGE=") and line.endswith(">>>"):
             if current_page is not None:

--- a/src/audit_lib/retrieval.py
+++ b/src/audit_lib/retrieval.py
@@ -1,8 +1,40 @@
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 from rapidfuzz import fuzz, process
 import re
-def chunk_pages_to_windows(pages: Dict[int,str], chunk_words=180, stride=90) -> List[Dict[str,Any]]:
-    chunks = []
+
+
+def chunk_pages_to_windows(
+    pages: Dict[int, str],
+    chunk_words: int = 180,
+    stride: int = 90,
+) -> List[Dict[str, Any]]:
+    """Split pages into overlapping word windows.
+
+    Parameters
+    ----------
+    pages: Dict[int, str]
+        Mapping of page numbers to their extracted text.
+    chunk_words: int, optional
+        Number of words per window. Must be positive.
+    stride: int, optional
+        Word offset between consecutive windows. Must be positive.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        A list of page window dictionaries containing ``page_start``,
+        ``page_end`` and ``text`` fields.
+
+    Raises
+    ------
+    ValueError
+        If ``chunk_words`` or ``stride`` is non-positive.
+    """
+
+    if chunk_words <= 0 or stride <= 0:
+        raise ValueError("chunk_words and stride must be positive")
+
+    chunks: List[Dict[str, Any]] = []
     for pno, text in pages.items():
         words = re.split(r"\s+", text.strip())
         if not words:
@@ -15,10 +47,40 @@ def chunk_pages_to_windows(pages: Dict[int,str], chunk_words=180, stride=90) -> 
                 "text": piece
             })
     return chunks
-def top_k_chunks_for_claim(claim: str, chunks: List[Dict[str,Any]], k=5) -> List[Dict[str,Any]]:
+
+
+def top_k_chunks_for_claim(
+    claim: str, chunks: List[Dict[str, Any]], k: int = 5
+) -> List[Dict[str, Any]]:
+    """Return the best matching text chunks for a claim.
+
+    Parameters
+    ----------
+    claim: str
+        The statement to match against the corpus.
+    chunks: List[Dict[str, Any]]
+        Candidate text chunks produced by :func:`chunk_pages_to_windows`.
+    k: int, optional
+        Number of results to return. Must be positive.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        A list of the top ``k`` chunks with ``page_range``, ``text`` and
+        ``score`` keys.
+
+    Raises
+    ------
+    ValueError
+        If ``k`` is non-positive.
+    """
+
+    if k <= 0:
+        raise ValueError("k must be positive")
+
     corpus = [c["text"] for c in chunks]
     ranked = process.extract(claim, corpus, scorer=fuzz.token_set_ratio, limit=k)
-    results = []
+    results: List[Dict[str, Any]] = []
     for (_, score, idx) in ranked:
         c = chunks[idx]
         results.append({

--- a/src/audit_lib/text_utils.py
+++ b/src/audit_lib/text_utils.py
@@ -1,8 +1,62 @@
 import re
+
 _SENT_SPLIT = re.compile(r'(?<=[.!?])\s+(?=[A-Z(“\"\[])')
-def split_sentences(text: str):
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split a block of text into individual sentences.
+
+    Parameters
+    ----------
+    text: str
+        Raw text to split.
+
+    Returns
+    -------
+    list[str]
+        List of sentences with surrounding whitespace removed. Returns an
+        empty list when ``text`` is empty.
+    """
+
     return [s.strip() for s in _SENT_SPLIT.split(text.strip()) if s.strip()]
+
+
 def has_numbers(s: str) -> bool:
+    """Check whether a string contains any numeric characters.
+
+    Parameters
+    ----------
+    s: str
+        String to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` if ``s`` contains at least one digit; otherwise ``False``.
+    """
+
     return bool(re.search(r"\d", s))
+
+
 def is_causal_or_normative(s: str) -> bool:
-    return bool(re.search(r"\b(lead(?:s|ing)?\s+to|cause(?:s|d)?|result(?:s|ed)?\s+in|should|must|best\s+practice|therefore|hence)\b", s, re.I))
+    """Determine if a string expresses causation or normative language.
+
+    Parameters
+    ----------
+    s: str
+        Sentence or phrase to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` if causal or normative keywords are found, otherwise
+        ``False``.
+    """
+
+    return bool(
+        re.search(
+            r"\b(lead(?:s|ing)?\s+to|cause(?:s|d)?|result(?:s|ed)?\s+in|should|must|best\s+practice|therefore|hence)\b",
+            s,
+            re.I,
+        )
+    )


### PR DESCRIPTION
## Summary
- add detailed docstrings and type hints for citation parsing helpers
- document retrieval utilities with input validation
- describe PDF, text and CSV helper functions including expected errors

## Testing
- `mypy src` *(fails: Library stubs not installed for "pandas"; type errors in `enrich.py` and `llm.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68c0408e21108329bc0126aa89396471