### PR TITLE
Use dataclass for parsed citations

### DIFF
--- a/scripts/10_extract_ccps.py
+++ b/scripts/10_extract_ccps.py
@@ -1,8 +1,11 @@
 import os, re, uuid, yaml, pandas as pd
 from pathlib import Path
+from typing import List
+
 from docx import Document
 from audit_lib.text_utils import split_sentences, has_numbers, is_causal_or_normative
 from audit_lib.citations import parse_citations
+from audit_lib.models import Citation
 
 CONFIG = yaml.safe_load(open("config/config.yaml","r",encoding="utf-8"))
 
@@ -67,7 +70,7 @@ def main():
         current_review_id = f.stem
         for section, line in infer_sections(lines):
             for sent in split_sentences(line):
-                cits = parse_citations(sent)
+                cits: List[Citation] = parse_citations(sent)
                 if not cits: 
                     continue
                 is_quote = bool(re.search(r'["“”\']', sent))
@@ -75,30 +78,35 @@ def main():
                 causal = is_causal_or_normative(sent)
                 for cit in cits:
                     claim_id = str(uuid.uuid4())[:8]
-                    fa_key = first_author_key(cit["author"])
-                    yr_key = cit["year"].lower()
+                    fa_key = first_author_key(cit.author)
+                    yr_key = cit.year.lower()
                     in_refs = (fa_key, yr_key) in refs_set if refs_set else ""
-                    pdf_guess = os.path.join(PDF_DIR, f"{cit['author'].split(',')[0].replace(' ','_')}_{cit['year']}.pdf")
-                    rows.append({
-                        "review_id": current_review_id,
-                        "section": section,
-                        "claim_id": claim_id,
-                        "claim_text": sent.strip(),
-                        "is_quote": is_quote,
-                        "has_numbers": nums,
-                        "is_causal_or_normative": causal,
-                        "citation_text": cit["citation_text"],
-                        "citation_type": cit["citation_type"],
-                        "citation_author": cit["author"],
-                        "citation_year": cit["year"],
-                        "is_secondary": bool(cit["is_secondary"]),
-                        "primary_mentioned_author": cit.get("primary_mentioned_author") or "",
-                        "primary_mentioned_year": cit.get("primary_mentioned_year") or "",
-                        "stated_page": cit.get("stated_page") or "",
-                        "in_reference_list": in_refs,
-                        "source_pdf_path": pdf_guess if os.path.exists(pdf_guess) else "",
-                        "priority": priority_flag(is_quote, nums, causal)
-                    })
+                    pdf_guess = os.path.join(
+                        PDF_DIR,
+                        f"{cit.author.split(',')[0].replace(' ','_')}_{cit.year}.pdf",
+                    )
+                    rows.append(
+                        {
+                            "review_id": current_review_id,
+                            "section": section,
+                            "claim_id": claim_id,
+                            "claim_text": sent.strip(),
+                            "is_quote": is_quote,
+                            "has_numbers": nums,
+                            "is_causal_or_normative": causal,
+                            "citation_text": cit.citation_text,
+                            "citation_type": cit.citation_type,
+                            "citation_author": cit.author,
+                            "citation_year": cit.year,
+                            "is_secondary": bool(cit.is_secondary),
+                            "primary_mentioned_author": cit.primary_mentioned_author or "",
+                            "primary_mentioned_year": cit.primary_mentioned_year or "",
+                            "stated_page": cit.stated_page or "",
+                            "in_reference_list": in_refs,
+                            "source_pdf_path": pdf_guess if os.path.exists(pdf_guess) else "",
+                            "priority": priority_flag(is_quote, nums, causal),
+                        }
+                    )
     if rows:
         pd.DataFrame(rows, columns=FIELDNAMES).to_csv(CCP_PATH, index=False)
         print(f"[OK] wrote {CCP_PATH}")

--- a/src/audit_lib/citations.py
+++ b/src/audit_lib/citations.py
@@ -1,5 +1,7 @@
 import re
-from typing import List, Dict, Any
+from typing import List
+
+from .models import Citation
 
 PAREN_BLOCK_RE = re.compile(r"\(([^()]+)\)")
 PAIR_RE = re.compile(r"([A-Z][^,;()]+?)\s*,\s*(\d{4}[a-z]?)")
@@ -7,8 +9,9 @@ NARR_RE = re.compile(r"\b([A-Z][A-Za-z'’\-]+(?:\s+(?:&|and)\s+[A-Z][A-Za-z'’
 AS_CITED_IN_RE = re.compile(r"\bas cited in\s+([A-Z][^,;()]+?)\s*,\s*(\d{4}[a-z]?)", re.I)
 PAGE_RE = re.compile(r"\bpp?\.\s*(\d+(?:\s*[-–]\s*\d+)?)", re.I)
 
-def _extract_parenthetical_pairs(sentence: str):
-    out = []
+
+def _extract_parenthetical_pairs(sentence: str) -> List[Citation]:
+    out: List[Citation] = []
     for m in PAREN_BLOCK_RE.finditer(sentence):
         block = m.group(1)
         span = (m.start(), m.end())
@@ -19,34 +22,39 @@ def _extract_parenthetical_pairs(sentence: str):
             stated_page = page_m.group(1).strip()
         if as_cited:
             host_author, host_year = as_cited.groups()
-            out.append({
-                "citation_text": "(" + block + ")",
-                "citation_type": "secondary_parenthetical",
-                "author": host_author.strip(),
-                "year": host_year.strip(),
-                "is_secondary": True,
-                "primary_mentioned_author": None,
-                "primary_mentioned_year": None,
-                "stated_page": stated_page,
-                "span": span,
-            })
+            out.append(
+                Citation(
+                    citation_text="(" + block + ")",
+                    citation_type="secondary_parenthetical",
+                    author=host_author.strip(),
+                    year=host_year.strip(),
+                    is_secondary=True,
+                    primary_mentioned_author=None,
+                    primary_mentioned_year=None,
+                    stated_page=stated_page,
+                    span=span,
+                )
+            )
             continue
         for a, y in PAIR_RE.findall(block):
-            out.append({
-                "citation_text": "(" + block + ")",
-                "citation_type": "parenthetical",
-                "author": a.strip(),
-                "year": y.strip(),
-                "is_secondary": False,
-                "primary_mentioned_author": None,
-                "primary_mentioned_year": None,
-                "stated_page": stated_page,
-                "span": span,
-            })
+            out.append(
+                Citation(
+                    citation_text="(" + block + ")",
+                    citation_type="parenthetical",
+                    author=a.strip(),
+                    year=y.strip(),
+                    is_secondary=False,
+                    primary_mentioned_author=None,
+                    primary_mentioned_year=None,
+                    stated_page=stated_page,
+                    span=span,
+                )
+            )
     return out
 
-def _extract_narrative_pairs(sentence: str):
-    out = []
+
+def _extract_narrative_pairs(sentence: str) -> List[Citation]:
+    out: List[Citation] = []
     for m in NARR_RE.finditer(sentence):
         a, y = m.groups()
         span = (m.start(), m.end())
@@ -58,38 +66,43 @@ def _extract_narrative_pairs(sentence: str):
             stated_page = page_m.group(1).strip()
         if as_cited:
             host_author, host_year = as_cited.groups()
-            out.append({
-                "citation_text": sentence[m.start():m.end()] + ", as cited in " + as_cited.group(0),
-                "citation_type": "secondary_narrative",
-                "author": host_author.strip(),
-                "year": host_year.strip(),
-                "is_secondary": True,
-                "primary_mentioned_author": a.strip(),
-                "primary_mentioned_year": y.strip(),
-                "stated_page": stated_page,
-                "span": span,
-            })
+            out.append(
+                Citation(
+                    citation_text=sentence[m.start():m.end()] + ", as cited in " + as_cited.group(0),
+                    citation_type="secondary_narrative",
+                    author=host_author.strip(),
+                    year=host_year.strip(),
+                    is_secondary=True,
+                    primary_mentioned_author=a.strip(),
+                    primary_mentioned_year=y.strip(),
+                    stated_page=stated_page,
+                    span=span,
+                )
+            )
         else:
-            out.append({
-                "citation_text": sentence[m.start():m.end()],
-                "citation_type": "narrative",
-                "author": a.strip(),
-                "year": y.strip(),
-                "is_secondary": False,
-                "primary_mentioned_author": None,
-                "primary_mentioned_year": None,
-                "stated_page": stated_page,
-                "span": span,
-            })
+            out.append(
+                Citation(
+                    citation_text=sentence[m.start():m.end()],
+                    citation_type="narrative",
+                    author=a.strip(),
+                    year=y.strip(),
+                    is_secondary=False,
+                    primary_mentioned_author=None,
+                    primary_mentioned_year=None,
+                    stated_page=stated_page,
+                    span=span,
+                )
+            )
     return out
 
-def parse_citations(sentence: str) -> List[Dict[str,Any]]:
+
+def parse_citations(sentence: str) -> List[Citation]:
     parenth = _extract_parenthetical_pairs(sentence)
     narr = _extract_narrative_pairs(sentence)
     seen = set()
-    out = []
+    out: List[Citation] = []
     for item in parenth + narr:
-        key = (item["author"], item["year"], item["citation_type"], item["span"])
+        key = (item.author, item.year, item.citation_type, item.span)
         if key not in seen:
             seen.add(key)
             out.append(item)

--- a/src/audit_lib/models.py
+++ b/src/audit_lib/models.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+@dataclass
+class Citation:
+    """Structured representation of a citation discovered in text."""
+    citation_text: str
+    citation_type: str
+    author: str
+    year: str
+    is_secondary: bool
+    primary_mentioned_author: Optional[str]
+    primary_mentioned_year: Optional[str]
+    stated_page: Optional[str]
+    span: Tuple[int, int]


### PR DESCRIPTION
## Summary
- Add `Citation` dataclass to model structured citation data
- Update `parse_citations` to produce and return `Citation` instances
- Refactor `10_extract_ccps.py` to consume `Citation` dataclass fields

## Testing
- `pytest` *(fails: OpenAIError The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68c041bfc2248329b6e73d5084068732